### PR TITLE
(READ COMMENT!!!) Re-implemented getFullName() full functionality

### DIFF
--- a/src/app/components/curriculum/curriculum.component.ts
+++ b/src/app/components/curriculum/curriculum.component.ts
@@ -34,7 +34,7 @@ export class CurriculumComponent implements OnInit {
   }
 
 
-  calendarOptions: CalendarOptions = {
+  calendarOptions: CalendarOptions & {dateClick: any} = {
     customButtons: {
       month: {
         text: 'Month',

--- a/src/app/jwt.ts
+++ b/src/app/jwt.ts
@@ -1,0 +1,3 @@
+export interface Jwt {
+    jwt: string
+}

--- a/src/app/services/user.service.spec.ts
+++ b/src/app/services/user.service.spec.ts
@@ -1,24 +1,105 @@
-import { TestBed } from '@angular/core/testing';
+import { TestBed, getTestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { UserService } from './user.service';
+import { User } from '../user';
+import { Jwt } from '../jwt';
+import { HttpHeaders } from '@angular/common/http';
 
-describe('UserService', () => {
+fdescribe('UserService', () => {
   let service: UserService;
+  let injector: TestBed;
+  let httpMock: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
-    service = TestBed.inject(UserService);
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [UserService]
+    });
+    injector = getTestBed();
+    service = injector.inject(UserService);
+    httpMock = injector.inject(HttpTestingController);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should expect a user', async () => {
-    // service.registerUser().subscribe(result => expect(result).toBe);
-    
-  })
+  it('getFirstName() should return an Observable updatable via setFirstName()', async() => {
+    const expectedName: string = "Test";
+    service.getFirstName().subscribe(name => expect(name).toBe(expectedName));
+    service.setFirstName(expectedName);
+  });
+
+  it('getLastName() should return an Observable updatable via setLastName()', async() => {
+    const expectedName: string = "Test";
+    service.getLastName().subscribe(name => expect(name).toBe(expectedName));
+    service.setLastName(expectedName);
+  });
+
+  it('should return a JSON of User when registerNewUser() is called', () => {
+    const dummyUserOutput: User = {
+      id: 0,
+      firstName: "Test",
+      lastName: "McGee",
+      username: "test",
+      trainer: false
+    }
+
+    let dummyUserInput: User & {password?: string}= dummyUserOutput;
+    dummyUserInput.password = "test123";
+
+    service.registerNewUser(dummyUserInput).subscribe((user) => {
+      expect(user.id).toEqual(dummyUserOutput.id);
+      expect(user.username).toEqual(dummyUserOutput.username);
+    });
+    const request = httpMock.expectOne("http://54.237.215.131:8082/revuser/register");
+    expect(request.request.method).toBe('POST');
+    request.flush(dummyUserOutput);
+  });
+
+  it('should return a JSON with a jwt when login() is called', () => {
+    const dummyJwt: Jwt = {
+      jwt: "thisIsAJwt"
+    }
+    const dummyUsername: string = "test";
+    const dummyPassword: string = "password";
+
+    service.login(dummyUsername, dummyPassword).subscribe((jwt) => {
+      expect(jwt.jwt).toEqual(dummyJwt.jwt);
+    });
+    const request = httpMock.expectOne("http://54.237.215.131:8082/revuser/authenticate");
+    expect(request.request.method).toBe('POST');
+    request.flush(dummyJwt);
+  });
+
+  it('should set new firstName/lastName when getFullName() called', async() => {
+    const mockJwt = "mock jwt";
+    const mockHttpOptions = {
+      headers: new HttpHeaders({
+        'Content-Type': "application/json",
+        'Authorization': mockJwt
+      })
+    }
+    const dummyFirstName: string = "Test1";
+    const dummyLastName: string = "Test2";
+    const dummyUserOutput: User = {
+      id: 0,
+      firstName: dummyFirstName,
+      lastName: dummyLastName,
+      username: "test",
+      trainer: false
+    }
+
+    service.getFirstName().subscribe(name => expect(name).toBe(dummyFirstName));
+    service.getLastName().subscribe(name => expect(name).toBe(dummyLastName));
+    service.getFullName(mockJwt);
+    const request = httpMock.expectOne("http://54.237.215.131:8082/revuser");
+    expect(request.request.method).toBe('GET');
+    request.flush(dummyUserOutput);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
 });
-
-
-

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { User } from '../user';
+import { Jwt } from '../jwt';
 import { HttpClient } from '@angular/common/http';
 import { HttpHeaders } from '@angular/common/http';
 import { Subject, Observable } from 'rxjs';
@@ -22,12 +23,34 @@ export class UserService {
   private lastNameChange = new Subject<string>();
   public lastName$ = this.lastNameChange.asObservable();
 
-  httpOptions: any = {
+  httpOptions = {
     headers: new HttpHeaders({
       "Content-Type": "application/json",
       "Authorization": ""
     })
   };
+
+    /**
+   * Getters for firstName and lastName which return AN OBSERVABLE.
+   */
+    getFirstName(): Observable<string> {
+      return this.firstName$;
+    }
+    getLastName(): Observable<string> {
+      return this.lastName$;
+    }
+  
+    /**
+     * Setters for firstName and lastName, includes functionality to push changes to the respective Observable.
+     */
+    setFirstName(newFirstName: string) {
+      this.firstName = newFirstName;
+      this.firstNameChange.next(newFirstName);
+    }
+    setLastName(newLastName: string) {
+      this.lastName = newLastName;
+      this.lastNameChange.next(newLastName);
+    }
 
   registerNewUser(newUser: User): Observable<User> {
     return this.http.post<User>(`${this.url}/register`, newUser).pipe(map((result: any) => {
@@ -48,14 +71,18 @@ export class UserService {
       username,
       password
     }
-    return this.http.post(`${this.url}/authenticate`, authObject);
+    return this.http.post<Jwt>(`${this.url}/authenticate`, authObject);
   }
 
   getFullName(jwt: string) {
     this.httpOptions.headers = this.httpOptions.headers.set('Authorization', `Bearer ${jwt}`);
     console.log(this.httpOptions)
-    this.http.get(`${this.url}`, this.httpOptions).subscribe((result) => {
-      console.log(result)
+    this.http.get(`${this.url}`, this.httpOptions).subscribe((result: any) => {
+      console.log(result);
+      this.getFirstName().subscribe(name => console.log(name));
+      this.getLastName().subscribe(name => console.log(name));
+      this.setFirstName(result.firstName);
+      this.setLastName(result.lastName);
     });
   }
 }


### PR DESCRIPTION
This is almost the same as one of the commits suspected to have broken old main! I tested this locally and verified that app and login still work on my end, but PLEASE pulling and running it + try logging in on your end as well before approving pull request!!
You can try logging in with username "test" and password "test", unless backend decides to truncate the RDS tables.

Change log:
- Re-added getters and setters for first/lastName Observables in UserService, and refactored getFullName() to call those setters when called (no changes made to Login component yet; right now getFullName() only prints the first and last names to console!)
- Also re-added UserService tests.
- **Minor edit to Curriculum component to resolve minor typing bug that was preventing tests from running** (told TypeScript that our calendarOptions should have an extra "dateClick" property that's not part of the CalendarOptions interface).