### PR TITLE
Saturday modules-topics work

### DIFF
--- a/src/app/components/all-topics/all-topics.component.html
+++ b/src/app/components/all-topics/all-topics.component.html
@@ -7,13 +7,13 @@
     <br>
     <input name="topicView" class="form-check-input" id="my-topics" type="radio" (click)="showMy()">
     <label class="form-check-label" for="my-topics">Show My Topics</label>
-</div>"
+</div>
 
 <div *ngIf="isShowingAll">
     <h2>All Topics</h2>
     <div>
         <ul>
-            <li *ngFor="let topic of topics" routerLink="/topic/{{topic.id}}">{{topic.title}}</li>
+            <li *ngFor="let topic of topics"><a routerLink="/topic/{{topic.id}}">{{topic.trainer.firstName}}: {{topic.title}}</a></li>
         </ul>
     </div>
 </div>
@@ -22,7 +22,7 @@
     <h2>My Topics</h2>
     <div>
         <ul>
-            <li *ngFor="let topic of myTopics" routerLink="/topic/{{topic.id}}">{{topic.title}}</li>
+            <li *ngFor="let topic of myTopics"><a routerLink="/topic/{{topic.id}}">{{topic.trainer.firstName}}: {{topic.title}}</a></li>
         </ul>
     </div>
 </div>

--- a/src/app/components/all-topics/all-topics.component.html
+++ b/src/app/components/all-topics/all-topics.component.html
@@ -1,12 +1,22 @@
 <app-navbar></app-navbar>
-<button class="rev-btn-confirm" (click)="refresh()">Refresh List</button>
 
-<div class="form-check">
+<!-- <div class="form-check">
     <input name="topicView" class="form-check-input" id="all-topics" type="radio" (click)="showAll()" checked>
     <label class="form-check-label" for="all-topics">Show All Topics</label>
     <br>
     <input name="topicView" class="form-check-input" id="my-topics" type="radio" (click)="showMy()">
     <label class="form-check-label" for="my-topics">Show My Topics</label>
+</div> -->
+
+<div class="btn-group btn-group-toggle" ngbRadioGroup name="topics-view" [(ngModel)]="isShowingAll">
+    <button class="rev-btn-confirm" (click)="refresh()">Refresh List</button>
+    <label style="color:white;" ngbButtonLabel class="rev-btn-confirm">
+        <input ngbButton type="radio" [value]="true"> Show All Topics
+    </label>
+    <label style="color:white;" ngbButtonLabel class="rev-btn-confirm">
+        <input ngbButton type="radio" [value]="false"> Show My Topics
+    </label>
+  
 </div>
 
 <div *ngIf="isShowingAll">
@@ -18,7 +28,7 @@
     </div>
 </div>
 
-<div *ngIf="isShowingMy">
+<div *ngIf="!isShowingAll">
     <h2>My Topics</h2>
     <div>
         <ul>

--- a/src/app/components/all-topics/all-topics.component.ts
+++ b/src/app/components/all-topics/all-topics.component.ts
@@ -13,7 +13,7 @@ export class AllTopicsComponent implements OnInit {
   topics: Topic[] = [];
   myTopics: Topic[] = [];
   isShowingAll: boolean = true;
-  isShowingMy: boolean = false;
+  //isShowingMy: boolean = false;
 
   constructor(private topicService: TopicService, private authService: AuthorizationService,
     private userService: UserService) { }
@@ -38,13 +38,13 @@ export class AllTopicsComponent implements OnInit {
     this.getTopics();
   }
 
-  showAll(): void {
-    this.isShowingAll = true;
-    this.isShowingMy = false;
-  }
+  // showAll(): void {
+  //   this.isShowingAll = true;
+  //   this.isShowingMy = false;
+  // }
 
-  showMy(): void {
-    this.isShowingAll = false;
-    this.isShowingMy = true;
-  }
+  // showMy(): void {
+  //   this.isShowingAll = false;
+  //   this.isShowingMy = true;
+  // }
 }

--- a/src/app/components/create-topic/create-topic.component.ts
+++ b/src/app/components/create-topic/create-topic.component.ts
@@ -7,6 +7,7 @@ import { AuthorizationService } from 'src/app/services/authorization.service';
 import { Module } from 'src/app/module';
 import { ModuleService } from 'src/app/services/module.service';
 import { Router } from '@angular/router';
+import { Topic } from 'src/app/topic';
 
 @Component({
   selector: 'app-create-topic',
@@ -42,18 +43,19 @@ export class CreateTopicComponent implements OnInit {
    * posted to the back-end API.
    */
   createTopic() {
-    let newTopicPostBody = {
+    let newTopic: Topic = {
+      id: 0,
       title: this.title,
       description: this.description,
       estimatedDuration: this.estimatedDuration,
       lectureNotes: this.lectureNotes,
       githubRepo: this.githubRepo,
-      trainer: this.userService.getUserId(),
-      technologyCategory: Number.parseInt(this.technologyCategoryId),
-      modules: [Number.parseInt(this.moduleId)]
+      trainer: this.userService.getUserObject(),
+      technologyCategory: this.techCategoryService.getCategoryByIdIfExists(Number.parseInt(this.technologyCategoryId)),
+      modules: []
     }
-    console.log(newTopicPostBody);
-    this.topicService.createTopic(this.authService.jwt, newTopicPostBody).subscribe( (result) => {
+    console.log(newTopic);
+    this.topicService.createTopic(this.authService.jwt, newTopic).subscribe( (result) => {
       console.log(result);
       this.successful = true;
       setTimeout(() => {

--- a/src/app/components/update-topic/update-topic/update-topic.component.html
+++ b/src/app/components/update-topic/update-topic/update-topic.component.html
@@ -2,53 +2,100 @@
 <div class="container mt-5"> 
     <div class="card shadow col-6 offset-3">
         <div class="card-body">
-            <div class="d-flex align-items-baseline justify-content-between">
-                <h3 class="card-title">Edit Topic</h3>
-                <button class="rev-btn-confirm" style="float:right;" (click)="deleteTopic()">Delete</button>
-            </div>
+            <div *ngIf=isTopicOwner>
+                <div class="d-flex align-items-baseline justify-content-between">
+                    <h3 class="card-title">Editing Topic</h3>
+                    <button class="rev-btn-confirm" style="float:right;" (click)="deleteTopic()">Delete</button>
+                </div>
 
-            <div class="mb-3">
-                <label for="title" class="form-label">Topic Title</label>
-                <input id="title" class="form-control" type="text" [(ngModel)]="title">
+                <div class="mb-3">
+                    <label for="title" class="form-label">Topic Title</label>
+                    <input id="title" class="form-control" type="text" [(ngModel)]="title">
+                </div>
+                <div class="mb-3">
+                    <label for="description" class="form-label">Description</label>
+                    <textarea class="form-control" id="description" [(ngModel)]="description"></textarea>
+                </div>
+                <div class="mb-3">
+                    <label for="estimatedTime" class="form-label">Estimated Time (in minutes)</label>
+                    <input id="estimatedTime" class="form-control" type="number" [(ngModel)]="estimatedDuration">
+                </div>
+                <div class="mb-3">
+                    <label for="lectureNotes" class="form-label">Lecture Notes</label>
+                    <textarea id="lectureNotes" class="form-control" [(ngModel)]="lectureNotes"></textarea>
+                </div>
+                <div class="mb-3">
+                    <label for="repoLink" class="form-label">Github Repo Link</label>
+                    <input id="repoLink" class="form-control" type="url" [(ngModel)]="githubRepo">
+                </div>
+                <div class="mb-3">
+                    <label for="techCategory" class="form-label">Category</label>
+                    <select id="techCategory" class="form-control" [(ngModel)]="technologyCategoryId">
+                        <option *ngFor="let techCategory of techCategories" value={{techCategory.id}}>{{techCategory.name}}</option>
+                    </select>
+                </div>
+                <div class="mb-3">
+                    <label for="modules" class="form-label">Module</label>
+                    <select id="modules" class="form-control" [(ngModel)]="moduleId">
+                        <option *ngFor="let module of modules" value={{module.id}}>{{module.name}}</option>
+                    </select>
+                </div>
+                <div *ngIf="successfulUpdate" id="success-message">
+                    Topic successfully updated!
+                </div>
+                <div *ngIf="successfulDelete" id="success-message">
+                    Topic successfully deleted!
+                </div>
+                <br>
+                <div>
+                    <button id="submit" class="rev-btn-confirm mr-2" (click)="updateTopic()">Submit</button>
+                    <button class="rev-btn-secondary" (click)="goBack()">Back</button>
+                </div>
             </div>
-            <div class="mb-3">
-                <label for="description" class="form-label">Description</label>
-                <textarea class="form-control" id="description" [(ngModel)]="description"></textarea>
-            </div>
-            <div class="mb-3">
-                <label for="estimatedTime" class="form-label">Estimated Time (in minutes)</label>
-                <input id="estimatedTime" class="form-control" type="number" [(ngModel)]="estimatedDuration">
-            </div>
-            <div class="mb-3">
-                <label for="lectureNotes" class="form-label">Lecture Notes</label>
-                <textarea id="lectureNotes" class="form-control" [(ngModel)]="lectureNotes"></textarea>
-            </div>
-            <div class="mb-3">
-                <label for="repoLink" class="form-label">Github Repo Link</label>
-                <input id="repoLink" class="form-control" type="url" [(ngModel)]="githubRepo">
-            </div>
-            <div class="mb-3">
-                <label for="techCategory" class="form-label">Category</label>
-                <select id="techCategory" class="form-control" [(ngModel)]="technologyCategoryId">
-                    <option *ngFor="let techCategory of techCategories" value={{techCategory.id}}>{{techCategory.name}}</option>
-                </select>
-            </div>
-            <div class="mb-3">
-                <label for="modules" class="form-label">Module</label>
-                <select id="modules" class="form-control" [(ngModel)]="moduleId">
-                    <option *ngFor="let module of modules" value={{module.id}}>{{module.name}}</option>
-                </select>
-            </div>
-            <div *ngIf="successfulUpdate" id="success-message">
-                Topic successfully updated!
-            </div>
-            <div *ngIf="successfulDelete" id="success-message">
-                Topic successfully deleted!
-            </div>
-            <br>
-            <div>
-                <button id="submit" class="rev-btn-confirm mr-2" (click)="updateTopic()">Submit</button>
-                <button class="rev-btn-secondary" routerLink="/modules">Back to Modules</button>
+            <div *ngIf="!isTopicOwner">
+                <div class="d-flex align-items-baseline justify-content-between">
+                    <h3 class="card-title">Viewing Topic</h3>
+                    <button class="rev-btn-confirm" style="float:right;" (click)="cloneTopic()">Clone</button>
+                </div>
+                <div class="mb-3">
+                    <label for="title" class="form-label">Topic Title</label>
+                    <input id="title" class="form-control" type="text" [(ngModel)]="title" readonly>
+                </div>
+                <div class="mb-3">
+                    <label for="description" class="form-label">Description</label>
+                    <textarea readonly class="form-control" id="description" [(ngModel)]="description"></textarea>
+                </div>
+                <div class="mb-3">
+                    <label for="estimatedTime" class="form-label">Estimated Time (in minutes)</label>
+                    <input readonly id="estimatedTime" class="form-control" type="number" [(ngModel)]="estimatedDuration">
+                </div>
+                <div class="mb-3">
+                    <label for="lectureNotes" class="form-label">Lecture Notes</label>
+                    <textarea readonly id="lectureNotes" class="form-control" [(ngModel)]="lectureNotes"></textarea>
+                </div>
+                <div class="mb-3">
+                    <label for="repoLink" class="form-label">Github Repo Link</label>
+                    <input readonly id="repoLink" class="form-control" type="url" [(ngModel)]="githubRepo">
+                </div>
+                <div class="mb-3">
+                    <label for="techCategory" class="form-label">Category</label>
+                    <select disabled id="techCategory" class="form-control" [(ngModel)]="technologyCategoryId">
+                        <option *ngFor="let techCategory of techCategories" value={{techCategory.id}}>{{techCategory.name}}</option>
+                    </select>
+                </div>
+                <div class="mb-3">
+                    <label for="modules" class="form-label">Module</label>
+                    <select disabled id="modules" class="form-control" [(ngModel)]="moduleId">
+                        <option *ngFor="let module of modules" value={{module.id}}>{{module.name}}</option>
+                    </select>
+                </div>
+                <div *ngIf="successfulClone" id="success-message">
+                    Topic successfully cloned!
+                </div>
+                <br>
+                <div>
+                    <button class="rev-btn-secondary" (click)="goBack()">Back</button>
+                </div>
             </div>
         </div>
     </div>

--- a/src/app/services/curriculum.service.spec.ts
+++ b/src/app/services/curriculum.service.spec.ts
@@ -23,7 +23,7 @@ describe('CurriculumService', () => {
     expect(service).toBeTruthy();
   });
 
-  fit('should return a list of curriculums with current user logged in', () => {
+  it('should return a list of curriculums with current user logged in', () => {
     let curriculums: Curriculum[] = [];
     service.getCurriculum().subscribe((result) => {
       expect(result).toBe(curriculums);

--- a/src/app/services/module.service.spec.ts
+++ b/src/app/services/module.service.spec.ts
@@ -70,4 +70,11 @@ describe('Service: Module', () => {
     mockRequest.flush(dummyModules);
   });
 
+  it('should return a Module with correct ID when getModuleById() is called after getAllModules()', () => {
+    service.getAllModules(mockJwt).subscribe((result: Module[]) => {
+      expect(service.getModuleById(1)).toEqual(result[0]);
+    })
+    const mockRequest = httpMock.expectOne(`${environment.revAssureBase}module`);
+    mockRequest.flush(dummyModules);
+  });
 });

--- a/src/app/services/module.service.ts
+++ b/src/app/services/module.service.ts
@@ -28,4 +28,13 @@ export class ModuleService {
       tap(modules => this.modules = modules)
     );
   }
+
+  getModuleById(id: number): Module | null {
+    for (let module of this.modules) {
+      if (module.id === id) {
+        return module;
+      }
+    }
+    return null;
+  }
 }

--- a/src/app/services/tech-category.service.spec.ts
+++ b/src/app/services/tech-category.service.spec.ts
@@ -59,4 +59,9 @@ describe('Service: TechCategory', () => {
     expect(mockRequest.request.method).toBe('GET');
     mockRequest.flush(dummyResponse);
   });
+
+  it('should return a dummy TechnologyCategory with ID 0 when getCategoryByIdIfExists() passes ID not on table', () => {
+    let returnedCategory = service.getCategoryByIdIfExists(545616);
+    expect(returnedCategory.id).toEqual(0);
+  });
 });

--- a/src/app/services/tech-category.service.ts
+++ b/src/app/services/tech-category.service.ts
@@ -14,11 +14,14 @@ import { TechnologyCategory, TechnologyCategoryAdapter } from '../technologycate
 })
 export class TechCategoryService {
 
-constructor(private http: HttpClient, private techCategoryAdapter: TechnologyCategoryAdapter) { }
+constructor(private http: HttpClient, private techCategoryAdapter: TechnologyCategoryAdapter) {
+  this.categories.push(this.nullCategory);
+ }
 
   url: string = `${environment.revAssureBase}technology_category`;
 
   categories : TechnologyCategory[] = [];
+  nullCategory: TechnologyCategory = new TechnologyCategory(0,"NULL",[],[]);
 
   httpOptions = {
     headers: new HttpHeaders({
@@ -33,13 +36,22 @@ constructor(private http: HttpClient, private techCategoryAdapter: TechnologyCat
    * @returns - an Observable with all the TechnologyCategories currently in the database
    */
   getAllCategories(jwt : string): Observable<TechnologyCategory[]> {
-      let data : TechnologyCategory[] = [];
-      this.httpOptions.headers = this.httpOptions.headers.set("Authorization", `Bearer ${jwt}`);
-      return this.http.get<any[]>(this.url, this.httpOptions).pipe(
-        map( (result: any[]) => {
-          result.forEach( (item : any) => this.categories.push(this.techCategoryAdapter.adapt(item)));
-          return this.categories;
-        })
-      )
+    let data : TechnologyCategory[] = [];
+    this.httpOptions.headers = this.httpOptions.headers.set("Authorization", `Bearer ${jwt}`);
+    return this.http.get<any[]>(this.url, this.httpOptions).pipe(
+      map( (result: any[]) => {
+        result.forEach( (item : any) => this.categories.push(this.techCategoryAdapter.adapt(item)));
+        return this.categories.slice(1);
+      })
+    )
+  }
+
+  getCategoryByIdIfExists(id: number): TechnologyCategory {
+    for (let category of this.categories) {
+      if (category.id === id) {
+        return category;
+      }
+    }
+    return this.categories[0];
   }
 }

--- a/src/app/services/topic.service.spec.ts
+++ b/src/app/services/topic.service.spec.ts
@@ -101,7 +101,7 @@ describe('TopicService: Topic', () => {
 
   //POST test
   it('should return a JSON of persisted topic when doing POST', () => {
-    service.createTopic(mockJwt, dummyTopicDto).subscribe((result : Topic) => {
+    service.createTopic(mockJwt, dummyTopics[0]).subscribe((result : Topic) => {
       expect(result).toEqual(dummyTopics[0]);
     })
     const mockRequest = httpMock.expectOne(`${environment.revAssureBase}topic`);
@@ -112,7 +112,7 @@ describe('TopicService: Topic', () => {
   //PUT test
   it('should return a JSON of persisted topic when doing PUT', () => {
     //let dummyTopicDtoPut = dummyTopicDto && { id: 1 };
-    service.updateTopic(mockJwt, dummyTopicDto).subscribe((result : Topic) => {
+    service.updateTopic(mockJwt, dummyTopics[0]).subscribe((result : Topic) => {
       expect(result).toEqual(dummyTopics[0]);
     })
     const mockRequest = httpMock.expectOne(`${environment.revAssureBase}topic`);

--- a/src/app/services/topic.service.ts
+++ b/src/app/services/topic.service.ts
@@ -3,12 +3,13 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import { Topic } from '../topic';
+import { UserService } from './user.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class TopicService {
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient, private userService: UserService) { }
 
   url: string = `${environment.revAssureBase}topic`;
 
@@ -19,6 +20,24 @@ export class TopicService {
     })
   };
 
+  convertToDto(topic: Topic) {
+    let dto = {
+      title: topic.title,
+      description: topic.description,
+      estimatedDuration: topic.estimatedDuration,
+      lectureNotes: topic.lectureNotes,
+      githubRepo: topic.githubRepo,
+      trainer: this.userService.getUserId(),
+      technologyCategory: topic.technologyCategory.id,
+      modules: [0]
+    }
+    dto.modules.pop();
+    for (let module of topic.modules) {
+      dto.modules.push(module.id);
+    }
+    return dto;
+  }
+
   /**
    * Performs a POST to "/topic" to create a new topic. Passes a topic DTO as required by the
    * back-end API point.
@@ -26,9 +45,11 @@ export class TopicService {
    * @param topic - DTO for persisting a new topic 
    * @returns an Observable containing the newly persisted Topic
    */
-  createTopic(jwt: string, topic: any): Observable<Topic> {
+  createTopic(jwt: string, topic: Topic): Observable<Topic> {
     this.httpOptions.headers = this.httpOptions.headers.set("Authorization", `Bearer ${jwt}`);
-    return this.http.post<Topic>(this.url, topic, this.httpOptions);
+    const dto = this.convertToDto(topic);
+    console.log(dto);
+    return this.http.post<Topic>(this.url, dto, this.httpOptions);
   }
 
   /**
@@ -51,9 +72,10 @@ export class TopicService {
     return this.http.get<Topic[]>(`${this.url}/all`, this.httpOptions);
   }
 
-  updateTopic(jwt: string, topic: any): Observable<Topic> {
+  updateTopic(jwt: string, topic: Topic): Observable<Topic> {
+    const dto = this.convertToDto(topic);
     this.httpOptions.headers = this.httpOptions.headers.set("Authorization", `Bearer ${jwt}`);
-    return this.http.put<Topic>(this.url, topic, this.httpOptions);
+    return this.http.put<Topic>(this.url, dto, this.httpOptions);
   }
 
   deleteTopicById(jwt: string, id: number): Observable<any> {


### PR DESCRIPTION
Added Topics button to dashboard which led to a Topic view where trainers can view either all topics or their own topics; refactored Update-Topic Component to also function as a non-editable Topic view when trainer doesn't own the topic being viewed; added Clone button to this view so trainer can clone currently viewed topic to their own list of topics.
Added get_ById functions to Module and TechCategory Services to internally filter for a module/tech category with a specific ID (does not involve new backend request).
Added convertToDto() function to TopicService; refactored createTopic() and updateTopic() to accept a Topic object as argument, which they then pass through convertToDto().